### PR TITLE
templates: update kvm-info-nfd-plugin image path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ test:
 #PACKAGE_VERSION represents version of whole package(labeller, cpu plugin, kvm info, ...)
 #LABELLER_VERSION represents version of kubevirt-node-labeller (https://github.com/kubevirt/node-labeller)
 #CPU_PLUGIN_VERSION represents version of kubevirt-cpu-nfd-plugin (https://github.com/kubevirt/cpu-nfd-plugin)
-#KVM_INFO_VERSION represents version of kvm-info-nfd-plugin (https://github.com/fromanirh/kvm-info-nfd-plugin)
+#KVM_INFO_VERSION represents version of kvm-info-nfd-plugin (https://github.com/kubevirt/kvm-info-nfd-plugin)
 #!!! ALL params are required !!!
-#example: make deploy-manifest PACKAGE_VERSION=v0.0.5 LABELLER_VERSION=v0.0.5 CPU_PLUGIN_VERSION=v0.0.4 KVM_INFO_VERSION=v0.4.0
+#example: make deploy-manifest PACKAGE_VERSION=v0.0.5 LABELLER_VERSION=v0.0.5 CPU_PLUGIN_VERSION=v0.0.4 KVM_INFO_VERSION=v0.5.6
 deploy-manifest:
 	deploy/templates/release.sh $(PACKAGE_VERSION) $(LABELLER_VERSION) $(CPU_PLUGIN_VERSION) $(KVM_INFO_VERSION)
 

--- a/deploy/templates/node-labeller-ds.yaml
+++ b/deploy/templates/node-labeller-ds.yaml
@@ -22,7 +22,7 @@ spec:
         args: ["infinity"]
       initContainers:
 
-        - image: quay.io/fromani/kvm-info-nfd-plugin:<KVM_INFO_VERSION>
+        - image: quay.io/kubevirt/kvm-info-nfd-plugin:<KVM_INFO_VERSION>
           command: ["/bin/sh","-c"]
           args: ["cp /usr/bin/kvm-caps-info-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/;"]
           imagePullPolicy: Always


### PR DESCRIPTION
The kvm-info-nfd-plugin now is fully under the kubevirt
umbrella, including the container images.

Signed-off-by: Francesco Romani <fromani@redhat.com>